### PR TITLE
Update to new image and path for tcpdump

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A simple wrapper script to run tcpdump nicely on Kubernetes.
 
 This tool will deploy a DaemonSet in the Kubernetes cluster using `kubectl` and run `tcpdump` on host network to capture network traffic.
 
-The DaemonSet is based on [praqma/network-multitool](https://github.com/Praqma/Network-MultiTool) Docker image.
+The DaemonSet is based on [wbitt/network-multitool](https://hub.docker.com/r/wbitt/network-multitool) Docker image.
 
 ### !! Important Note: Please use this tool in production by **CAUTION** !!
 

--- a/ktcpdump
+++ b/ktcpdump
@@ -130,7 +130,7 @@ run () {
     done
 
     extra_args=$(printf "%s " "${extra_args[@]}")
-    echo "/usr/sbin/tcpdump $default_args $extra_args"
+    echo "/usr/bin/tcpdump $default_args $extra_args"
     sed -e "s/__DEFAULT_ARGS__/$default_args/" \
         -e "s/__EXTRA_ARGS__/$extra_args/" \
         kube/ds.yaml | kubectl apply --validate=true -f -

--- a/kube/ds.yaml
+++ b/kube/ds.yaml
@@ -25,7 +25,7 @@ spec:
         effect: NoSchedule
       terminationGracePeriodSeconds: 0
       containers:
-      - image: praqma/network-multitool:latest
+      - image: wbitt/network-multitool:latest
         imagePullPolicy: IfNotPresent
         name: network-multitool
         resources:
@@ -37,7 +37,7 @@ spec:
           capabilities:
             add: ["NET_ADMIN"]
         command: ["/bin/sh", "-c"]
-        args: ["/usr/sbin/tcpdump __DEFAULT_ARGS__ __EXTRA_ARGS__; tail -f /dev/null"]
+        args: ["/usr/bin/tcpdump __DEFAULT_ARGS__ __EXTRA_ARGS__; tail -f /dev/null"]
         env:
         - name: HOST_IP
           valueFrom:


### PR DESCRIPTION
Thank you for this tool! Was exactly what I was looking for.

This PR updates the image and the path for tcpdump because the previous sbin path didn't have tcpdump in it anymore.